### PR TITLE
Add expected payoff graph to Kuhn CFR

### DIFF
--- a/cfr_kuhn_vanilla.py
+++ b/cfr_kuhn_vanilla.py
@@ -194,6 +194,24 @@ def card_str(card: int) -> str:
     """整数表現を 'J','Q','K' の文字列へ変換。"""
     return ("J", "Q", "K")[card]
 
+def describe_history(history: str) -> str:
+    """履歴文字列を日本語の人間可読形式に変換する。"""
+    # 'rr' は配札を表すダミーなので無視
+    actions = []
+    bet_happened = False
+    # 先手は P1, 次手は P2 ... と交互
+    for i, ch in enumerate(history[2:]):
+        actor = "P1" if i % 2 == 0 else "P2"
+        if ch == "c":
+            action = "チェック" if not bet_happened else "フォールド"
+        else:  # 'b'
+            action = "ベット" if not bet_happened else "コール"
+            if not bet_happened:
+                bet_happened = True
+        actions.append(f"{actor}:{action}")
+
+    return "開始直後" if not actions else "→".join(actions)
+
 def get_info_set(
     i_map: dict[str, "InformationSet"],
     card: int,
@@ -265,8 +283,11 @@ class InformationSet:
 
     # ─── デバッグ用表示 ─────────────────────────────────────
     def __str__(self) -> str:
+        card, history = self.key.split()
+        readable = describe_history(history)
         probs = [f"{p:0.2f}" for p in self.get_average_strategy()]
-        return f"{self.key.ljust(6)} {probs}"
+        prob_str = "/".join(probs)
+        return f"カード{card} | 履歴: {readable} | 戦略: {prob_str}"
 
 # ──────────────────────────────────────────────────────────────
 # 結果表示

--- a/cfr_kuhn_vanilla.py
+++ b/cfr_kuhn_vanilla.py
@@ -21,6 +21,8 @@ $ python cfr_kuhn_vanilla.py
 """
 
 import numpy as np
+import matplotlib.pyplot as plt
+import japanize_matplotlib
 
 # ──────────────────────────────────────────────────────────────
 # 定数定義
@@ -42,18 +44,22 @@ def main() -> None:
     n_iterations = 10_000           # 反復回数（精度が欲しければ増やす）
 
     expected_game_value = 0.0       # 反復ごとのゲーム値を累積
+    ev_history: list[float] = []    # プレイヤー1の期待利得推移
 
-    for _ in range(n_iterations):
+    for t in range(1, n_iterations + 1):
         expected_game_value += cfr(i_map)      # 1 回分の木探索 → 利得を加算
 
         # 1 反復が終わったら全情報集合で次回戦略を計算
         for info_set in i_map.values():
             info_set.next_strategy()
 
+        ev_history.append(expected_game_value / t)
+
     # 反復平均を取ることで近似ゲーム値を得る
     expected_game_value /= n_iterations
 
     display_results(expected_game_value, i_map)
+    plot_ev_history(ev_history)
 
 # ──────────────────────────────────────────────────────────────
 # CFR 本体 – 深さ優先でゲーム木を全探索（Vanilla CFR）
@@ -277,6 +283,21 @@ def display_results(ev: float, i_map: dict[str, InformationSet]) -> None:
     print("\nplayer 2 strategies:")
     for _, v in sorted(filter(lambda kv: len(kv[0]) % 2 == 1, i_map.items())):
         print(v)
+
+def plot_ev_history(ev_history: list[float]) -> None:
+    """反復ごとの期待利得推移をグラフ表示する。"""
+    iterations = np.arange(1, len(ev_history) + 1)
+
+    plt.figure()
+    plt.plot(iterations, ev_history, label="プレイヤー1")
+    plt.plot(iterations, -np.array(ev_history), label="プレイヤー2")
+    plt.xlabel("反復回数")
+    plt.ylabel("期待利得")
+    plt.title("期待利得の変化")
+    plt.legend()
+    plt.grid(True, alpha=0.3)
+    plt.tight_layout()
+    plt.show()
 
 # ──────────────────────────────────────────────────────────────
 # エントリポイント

--- a/cfr_kuhn_vanilla.py
+++ b/cfr_kuhn_vanilla.py
@@ -212,6 +212,13 @@ def describe_history(history: str) -> str:
 
     return "開始直後" if not actions else "→".join(actions)
 
+def action_labels(history: str) -> tuple[str, str]:
+    """その情報集合で選択できる行動名を返す。"""
+    bet_happened = "b" in history[2:]
+    if bet_happened:
+        return ("フォールド", "コール")
+    return ("チェック", "ベット")
+
 def get_info_set(
     i_map: dict[str, "InformationSet"],
     card: int,
@@ -285,8 +292,9 @@ class InformationSet:
     def __str__(self) -> str:
         card, history = self.key.split()
         readable = describe_history(history)
+        actions = action_labels(history)
         probs = [f"{p:0.2f}" for p in self.get_average_strategy()]
-        prob_str = "/".join(probs)
+        prob_str = f"{actions[0]}:{probs[0]} / {actions[1]}:{probs[1]}"
         return f"カード{card} | 履歴: {readable} | 戦略: {prob_str}"
 
 # ──────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- visualize the training progress in `cfr_kuhn_vanilla.py`
- plot expected payoffs for both players as CFR iterates

## Testing
- `python -m py_compile cfr_kuhn_vanilla.py`
- `MPLBACKEND=Agg python cfr_kuhn_vanilla.py`

------
https://chatgpt.com/codex/tasks/task_e_6845983cb0388328bacf2d21c4bc2201